### PR TITLE
Fix: 'record'  not freed upon failure

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -63,6 +63,9 @@ static struct cmusfm_cache_record *get_cache_record(const scrobbler_trackinfo_t 
 
 	/* allocate memory for the initial record data (header) */
 	record = (struct cmusfm_cache_record *)calloc(1, sizeof(*record));
+	if (record == NULL) {
+		return NULL;
+	}
 
 	record->signature = CMUSFM_CACHE_SIGNATURE;
 	record->timestamp = sb_tinf->timestamp;
@@ -81,12 +84,10 @@ static struct cmusfm_cache_record *get_cache_record(const scrobbler_trackinfo_t 
 		record->len_mb_track_id = strlen(sb_tinf->mb_track_id) + 1;
 
 	/* enlarge allocated memory for string data payload */
-	record = (struct cmusfm_cache_record *)realloc(record, get_cache_record_size(record));
-
-	if (record == NULL) {
-		perror("ERROR: error enlarge allocated memory");
-		free(record);
-		exit(EXIT_FAILURE);
+	struct cmusfm_cache_record *tmp = record;
+	if ((record = realloc(tmp, get_cache_record_size(record))) == NULL) {
+		free(tmp);
+		return NULL;
 	}
 
 	ptr = (char *)&record[1];

--- a/src/cache.c
+++ b/src/cache.c
@@ -82,6 +82,13 @@ static struct cmusfm_cache_record *get_cache_record(const scrobbler_trackinfo_t 
 
 	/* enlarge allocated memory for string data payload */
 	record = (struct cmusfm_cache_record *)realloc(record, get_cache_record_size(record));
+
+	if (record == NULL) {
+		perror("ERROR: error enlarge allocated memory");
+		free(record);
+		exit(EXIT_FAILURE);
+	}
+
 	ptr = (char *)&record[1];
 
 	if (record->len_artist) {


### PR DESCRIPTION
I checked the code with `cppcheck` and got an error:
```sh
Checking cmusfm/src/cache.c ...
cmusfm/src/cache.c:84:2: error: Common realloc mistake: 'record' nulled but not freed upon failure [memleakOnRealloc]
record = (struct cmusfm_cache_record *)realloc(record, get_cache_record_size(record));
```
